### PR TITLE
Change private_registry_username back to a normal variable

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/GetClusterProfileMetadataExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/GetClusterProfileMetadataExecutor.java
@@ -39,7 +39,7 @@ public class GetClusterProfileMetadataExecutor implements RequestExecutor {
     public static final Metadata ENABLE_PRIVATE_REGISTRY_AUTHENTICATION = new Metadata("enable_private_registry_authentication", false, false);
     public static final Metadata PRIVATE_REGISTRY_SERVER = new Metadata("private_registry_server", false, false);
     public static final Metadata PRIVATE_REGISTRY_CUSTOM_CREDENTIALS = new Metadata("private_registry_custom_credentials", false, false);
-    public static final Metadata PRIVATE_REGISTRY_USERNAME = new Metadata("private_registry_username", false, true);
+    public static final Metadata PRIVATE_REGISTRY_USERNAME = new Metadata("private_registry_username", false, false);
     public static final Metadata PRIVATE_REGISTRY_PASSWORD = new Metadata("private_registry_password", false, true);
     public static final Metadata PULL_ON_CONTAINER_CREATE = new Metadata("pull_on_container_create", false, false);
 

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/GetClusterProfilePropertiesMetadataExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/GetClusterProfilePropertiesMetadataExecutorTest.java
@@ -93,7 +93,7 @@ public class GetClusterProfilePropertiesMetadataExecutorTest {
                 "  }," +
                 "  {" +
                 "      \"key\":\"private_registry_username\"," +
-                "      \"metadata\":{\"required\":false,\"secure\":true}" +
+                "      \"metadata\":{\"required\":false,\"secure\":false}" +
                 "  }," +
                 "  {" +
                 "      \"key\":\"private_registry_password\"," +


### PR DESCRIPTION
As discussed in https://github.com/gocd-contrib/docker-elastic-agents-plugin/issues/210#issuecomment-1478012111