### PR TITLE
Ensure user is forced to clear private registry custom credentials before switching to use docker config file for auth

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/docker/DockerClientFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/DockerClientFactory.java
@@ -56,7 +56,7 @@ public class DockerClientFactory {
             setupCerts(pluginSettings, builder);
         }
 
-        if (pluginSettings.useDockerAuthInfo()) {
+        if (pluginSettings.enablePrivateRegistryAuthentication()) {
             RegistryAuth auth;
             if (pluginSettings.useCustomRegistryCredentials()) {
                 auth = RegistryAuth.builder()

--- a/src/main/java/cd/go/contrib/elasticagents/docker/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/PluginSettings.java
@@ -78,7 +78,7 @@ public class PluginSettings {
 
     @Expose
     @SerializedName("enable_private_registry_authentication")
-    private boolean useDockerAuthInfo;
+    private boolean enablePrivateRegistryAuthentication;
 
     @Expose
     @SerializedName("private_registry_custom_credentials")
@@ -112,7 +112,8 @@ public class PluginSettings {
             return false;
         if (dockerClientKey != null ? !dockerClientKey.equals(that.dockerClientKey) : that.dockerClientKey != null)
             return false;
-        if (useDockerAuthInfo != that.useDockerAuthInfo) return false;
+        if (enablePrivateRegistryAuthentication != that.enablePrivateRegistryAuthentication)
+            return false;
         if(privateRegistryServer != null ? !privateRegistryServer.equals(that.privateRegistryServer) : that.privateRegistryServer != null)
             return false;
         if (useCustomRegistryCredentials != that.useCustomRegistryCredentials) return false;
@@ -134,7 +135,7 @@ public class PluginSettings {
         result = 31 * result + (dockerClientCert != null ? dockerClientCert.hashCode() : 0);
         result = 31 * result + (dockerClientKey != null ? dockerClientKey.hashCode() : 0);
         result = 31 * result + (autoRegisterPeriod != null ? autoRegisterPeriod.hashCode() : 0);
-        result = 31 * result + (useDockerAuthInfo?1:0);
+        result = 31 * result + (enablePrivateRegistryAuthentication?1:0);
         result = 31 * result + (privateRegistryServer != null ? privateRegistryServer.hashCode() : 0);
         result = 31 * result + (useCustomRegistryCredentials? 1 : 0);
         result = 31 * result + (privateRegistryPassword != null ? privateRegistryPassword.hashCode() : 0);
@@ -201,8 +202,8 @@ public class PluginSettings {
         return privateRegistryPassword;
     }
 
-    public Boolean useDockerAuthInfo() {
-        return Boolean.valueOf(useDockerAuthInfo);
+    public Boolean enablePrivateRegistryAuthentication() {
+        return Boolean.valueOf(enablePrivateRegistryAuthentication);
     }
 
     public Boolean useCustomRegistryCredentials() {
@@ -255,7 +256,7 @@ public class PluginSettings {
                 ", privateRegistryServer='" + privateRegistryServer + '\'' +
                 ", privateRegistryUsername='" + privateRegistryUsername + '\'' +
                 ", privateRegistryPassword='" + privateRegistryPassword + '\'' +
-                ", useDockerAuthInfo=" + useDockerAuthInfo +
+                ", enablePrivateRegistryAuthentication=" + enablePrivateRegistryAuthentication +
                 ", useCustomRegistryCredentials=" + useCustomRegistryCredentials +
                 ", pullOnContainerCreate=" + pullOnContainerCreate +
                 ", autoRegisterPeriod=" + autoRegisterPeriod +

--- a/src/main/java/cd/go/contrib/elasticagents/docker/executors/ClusterProfileValidateRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/docker/executors/ClusterProfileValidateRequestExecutor.java
@@ -21,9 +21,9 @@ import cd.go.contrib.elasticagents.docker.requests.ClusterProfileValidateRequest
 import com.google.gson.Gson;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 
 import static cd.go.contrib.elasticagents.docker.executors.GetClusterProfileMetadataExecutor.FIELDS;
 
@@ -36,14 +36,9 @@ public class ClusterProfileValidateRequestExecutor implements RequestExecutor {
         this.request = request;
     }
 
-    private String getRequestProperty(String key) {
-        return request.getProperties().get(key);
-    }
-
     @Override
     public GoPluginApiResponse execute() {
-        ArrayList<Map<String, String>> result = new ArrayList<>();
-
+        List<Map<String, String>> result = new ArrayList<>();
         List<String> knownFields = new ArrayList<>();
 
         for (Metadata field : FIELDS) {
@@ -60,10 +55,7 @@ public class ClusterProfileValidateRequestExecutor implements RequestExecutor {
 
         if (!set.isEmpty()) {
             for (String key : set) {
-                LinkedHashMap<String, String> validationError = new LinkedHashMap<>();
-                validationError.put("key", key);
-                validationError.put("message", "Is an unknown property");
-                result.add(validationError);
+                result.add(Map.of("key", key, "message", "Is an unknown property"));
             }
         }
 
@@ -72,39 +64,43 @@ public class ClusterProfileValidateRequestExecutor implements RequestExecutor {
         return DefaultGoPluginApiResponse.success(GSON.toJson(result));
     }
 
-    private ArrayList<Map<String, String>> validateNoDanglingPrivateRegistryCredentials() {
-        ArrayList<Map<String, String>> result = new ArrayList<>();
+    private List<Map<String, String>> validateNoDanglingPrivateRegistryCredentials() {
+        List<Map<String, String>> result = new ArrayList<>();
 
         String enablePrivateRegistryAuthentication = getRequestProperty("enable_private_registry_authentication");
         String privateRegistryCustomCredentials = getRequestProperty("private_registry_custom_credentials");
-        boolean usePrivateRegistry = enablePrivateRegistryAuthentication == null ? false : enablePrivateRegistryAuthentication.equals("true");
-        boolean useCustomRegistryCredentials = privateRegistryCustomCredentials == null ? false : privateRegistryCustomCredentials.equals("true");
+        boolean usePrivateRegistry = "true".equals(enablePrivateRegistryAuthentication);
+        boolean useCustomRegistryCredentials = "true".equals(privateRegistryCustomCredentials);
         boolean privateRegistryUsernameIsPresent = !StringUtils.isBlank(getRequestProperty("private_registry_username"));
         boolean privateRegistryPasswordIsPresent = !StringUtils.isBlank(getRequestProperty("private_registry_password"));
 
         if (usePrivateRegistry && !useCustomRegistryCredentials) {
             if (privateRegistryPasswordIsPresent || privateRegistryUsernameIsPresent) {
-                HashMap<String, String> validationError = new HashMap<>();
-                validationError.put("key", "enable_private_registry_authentication");
-                validationError.put("message", "Please clear your private registry credentials before switching from custom credentials to using the docker configuration file.");
-                result.add(validationError);
+                result.add(Map.of(
+                        "key", "enable_private_registry_authentication",
+                        "message", "Please clear your private registry credentials before switching from custom credentials to using the docker configuration file."
+                ));
             }
 
             if (privateRegistryUsernameIsPresent) {
-                HashMap<String, String> validationError = new HashMap<>();
-                validationError.put("key", "private_registry_username");
-                validationError.put("message", "Please clear your private registry username before switching from custom credentials to using the docker configuration file.");
-                result.add(validationError);
+                result.add(Map.of(
+                        "key", "private_registry_username",
+                        "message", "Please clear your private registry username before switching from custom credentials to using the docker configuration file."
+                ));
             }
 
             if (privateRegistryPasswordIsPresent) {
-                HashMap<String, String> validationError = new HashMap<>();
-                validationError.put("key", "private_registry_password");
-                validationError.put("message", "Please clear your private registry password before switching from custom credentials to using the docker configuration file.");
-                result.add(validationError);
+                result.add(Map.of(
+                        "key", "private_registry_password",
+                        "message", "Please clear your private registry password before switching from custom credentials to using the docker configuration file."));
             }
         }
 
         return result;
     }
+
+    private String getRequestProperty(String key) {
+        return request.getProperties().get(key);
+    }
+
 }

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ClusterProfilePropertiesValidateRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ClusterProfilePropertiesValidateRequestExecutorTest.java
@@ -42,8 +42,6 @@ public class ClusterProfilePropertiesValidateRequestExecutorTest {
                 mandatoryFieldsBaseErrorString +
                 "]\n";
 
-        System.out.println(expectedStr);
-
         JSONAssert.assertEquals(expectedStr, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -61,7 +59,7 @@ public class ClusterProfilePropertiesValidateRequestExecutorTest {
 
     @Test
     public void shouldComplainWhenUserSwitchesToDockerConfigWithoutClearingCustomCredentials() throws Exception {
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("enable_private_registry_authentication", "true");
         properties.put("private_registry_custom_credentials", "false");
         properties.put("private_registry_username", "some username");

--- a/src/test/java/cd/go/contrib/elasticagents/docker/executors/ClusterProfilePropertiesValidateRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/docker/executors/ClusterProfilePropertiesValidateRequestExecutorTest.java
@@ -22,32 +22,63 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ClusterProfilePropertiesValidateRequestExecutorTest {
+    String mandatoryFieldsBaseErrorString = "  {\"message\":\"Go Server URL must not be blank.\",\"key\":\"go_server_url\"},"
+            +
+            "  {\"message\":\"max_docker_containers must not be blank.\",\"key\":\"max_docker_containers\"}," +
+            "  {\"message\":\"docker_uri must not be blank.\",\"key\":\"docker_uri\"}," +
+            "  {\"message\":\"auto_register_timeout must not be blank.\",\"key\":\"auto_register_timeout\"}";
+
+    @Test
+    public void shouldValidateMandatoryKeys() throws Exception {
+        ClusterProfileValidateRequestExecutor executor = new ClusterProfileValidateRequestExecutor(
+                new ClusterProfileValidateRequest(Collections.<String, String>emptyMap()));
+        String json = executor.execute().responseBody();
+
+        String expectedStr = "[" +
+                mandatoryFieldsBaseErrorString +
+                "]\n";
+
+        System.out.println(expectedStr);
+
+        JSONAssert.assertEquals(expectedStr, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
     @Test
     public void shouldBarfWhenUnknownKeysArePassed() throws Exception {
-        ClusterProfileValidateRequestExecutor executor = new ClusterProfileValidateRequestExecutor(new ClusterProfileValidateRequest(Collections.singletonMap("foo", "bar")));
+        ClusterProfileValidateRequestExecutor executor = new ClusterProfileValidateRequestExecutor(
+                new ClusterProfileValidateRequest(Collections.singletonMap("foo", "bar")));
         String json = executor.execute().responseBody();
         String expectedStr = "[" +
-                "  {\"message\":\"Go Server URL must not be blank.\",\"key\":\"go_server_url\"}," +
-                "  {\"message\":\"max_docker_containers must not be blank.\",\"key\":\"max_docker_containers\"}," +
-                "  {\"message\":\"docker_uri must not be blank.\",\"key\":\"docker_uri\"}," +
-                "  {\"message\":\"auto_register_timeout must not be blank.\",\"key\":\"auto_register_timeout\"}," +
-                "  {\"key\":\"foo\",\"message\":\"Is an unknown property\"}" +
+                mandatoryFieldsBaseErrorString +
+                ", {\"key\":\"foo\",\"message\":\"Is an unknown property\"}" +
                 "]";
         JSONAssert.assertEquals(expectedStr, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
-    public void shouldValidateMandatoryKeys() throws Exception {
-        ClusterProfileValidateRequestExecutor executor = new ClusterProfileValidateRequestExecutor(new ClusterProfileValidateRequest(Collections.<String, String>emptyMap()));
+    public void shouldComplainWhenUserSwitchesToDockerConfigWithoutClearingCustomCredentials() throws Exception {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("enable_private_registry_authentication", "true");
+        properties.put("private_registry_custom_credentials", "false");
+        properties.put("private_registry_username", "some username");
+        properties.put("private_registry_password", "some password");
+
+        ClusterProfileValidateRequestExecutor executor = new ClusterProfileValidateRequestExecutor(
+                new ClusterProfileValidateRequest(properties));
         String json = executor.execute().responseBody();
 
         String expectedStr = "[" +
-                "  {\"message\":\"Go Server URL must not be blank.\",\"key\":\"go_server_url\"}," +
-                "  {\"message\":\"max_docker_containers must not be blank.\",\"key\":\"max_docker_containers\"}," +
-                "  {\"message\":\"docker_uri must not be blank.\",\"key\":\"docker_uri\"}," +
-                "  {\"message\":\"auto_register_timeout must not be blank.\",\"key\":\"auto_register_timeout\"}" +
+                mandatoryFieldsBaseErrorString +
+                ", {\"message\":\"Please clear your private registry credentials before switching from custom credentials to using the docker configuration file.\",\"key\":\"enable_private_registry_authentication\"},"
+                +
+                "  {\"message\":\"Please clear your private registry username before switching from custom credentials to using the docker configuration file.\",\"key\":\"private_registry_username\"},"
+                +
+                "  {\"message\":\"Please clear your private registry password before switching from custom credentials to using the docker configuration file.\",\"key\":\"private_registry_password\"}"
+                +
                 "]\n";
 
         JSONAssert.assertEquals(expectedStr, json, JSONCompareMode.NON_EXTENSIBLE);


### PR DESCRIPTION
Currently, if the user chooses to use a private docker registry, and sets custom credentials for authenticating, the `private_registry_username` and `private_registry_password` fields are not cleared even when the user eventually switches over to using the docker configuration file for auth. This could be especially problematic for certain use-cases where the private registry username, which is displayed in plaintext on the UI, could contain sensitive information (eg. DigitalOcean private registry uses the same secret API token for the both the username and password fields for authentication)

I couldn't figure out where the plugin settings form data were being saved (am assuming the logic lies in core GoCD code), so while we can't automatically clear out those values before saving, from the plugin side we can throw a validation error if the user switches to use a docker configuration file for auth but has not cleared any previously set custom credentials.

As discussed in https://github.com/gocd-contrib/docker-elastic-agents-plugin/issues/210#issuecomment-1477903732

Tested a local build with these changes:
GoCD server version: 22.3.0
Environment: DigitalOcean Droplet, Docker 20.10.21 on Ubuntu 22.04

The following validation errors will show up on the cluster settings form if the user chooses to switch to docker config auth and tries to save before clearing out custom credentials
![image](https://user-images.githubusercontent.com/11689299/229111623-5d9348aa-da98-418f-ae66-117933ef8f24.png)

![image](https://user-images.githubusercontent.com/11689299/229111580-145f1a25-35c6-4466-91c3-07fe1ab2b22c.png)

Also cleaned up a small inconsistency in variable naming re: `useDockerAuthInfo` vs `enablePrivateRegistryCredentials`.