### PR TITLE
Bump JNR transitive dependency to version that works on M1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ dependencies {
     implementation('commons-io:commons-io:2.12.0' ) {
       because 'spotify docker-client uses an outdated version'
     }
+    implementation('com.github.jnr:jnr-unixsocket:0.38.19' ) {
+      because 'spotify docker-client uses an outdated version'
+    }
   }
 
   testImplementation project.deps.gocdPluginApi


### PR DESCRIPTION
Corrects behaviour when running on M1