### PR TITLE
Correct plugin to work against Docker 25

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -14,6 +14,7 @@ jobs:
           - "20.10" # 2020-12 --> EOL 2023-12-10
           - "23.0"  # 2023-02 --> EOL ?
           - "24.0"  # 2023-05 --> EOL ?
+          - "25.0"  # 2024-01 --> EOL ?
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -16,6 +16,7 @@ jobs:
           - "20.10" # 2020-12 --> EOL 2023-12-10
           - "23.0"  # 2023-02 --> EOL ?
           - "24.0"  # 2023-05 --> EOL ?
+          - "25.0"  # 2024-01 --> EOL ?
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply from: "https://raw.githubusercontent.com/gocd/gocd-plugin-gradle-task-help
 
 gocdPlugin {
   id = 'cd.go.contrib.elastic-agent.docker'
-  pluginVersion = '3.2.3'
+  pluginVersion = '3.2.4'
   goCdVersion = '20.9.0'
   name = 'Docker Elastic Agent Plugin'
   description = 'Docker Based Elastic Agent Plugins for GoCD'

--- a/src/main/java/com/spotify/docker/client/messages/AutoValue_ImageInfo.java
+++ b/src/main/java/com/spotify/docker/client/messages/AutoValue_ImageInfo.java
@@ -1,0 +1,279 @@
+/*-
+ * Generated code derived from code Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This is a hacked override for the non-nullability of the "virtualSize" field in ImageInfo from
+ * the EOL Spotify docker-client at https://github.com/spotify/docker-client/blob/9a7c3b4994be9a55988f821f7177029201ff6aef/src/main/java/com/spotify/docker/client/messages/ImageInfo.java#L74-L75
+ *
+ * This *should* work OK, as I believe classpath for plugins using nested lib loading is deterministic and should load
+ * before the dependencies themselves.
+ *
+ * See https://github.com/gocd-contrib/docker-elastic-agents-plugin/issues/258 for longer term fix.
+ */
+package com.spotify.docker.client.messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Generated;
+import java.util.Date;
+
+@Generated("com.google.auto.value.processor.AutoValueProcessor")
+ final class AutoValue_ImageInfo extends ImageInfo {
+
+  private final String id;
+  private final String parent;
+  private final String comment;
+  private final Date created;
+  private final String container;
+  private final ContainerConfig containerConfig;
+  private final String dockerVersion;
+  private final String author;
+  private final ContainerConfig config;
+  private final String architecture;
+  private final String os;
+  private final Long size;
+  private final Long virtualSize;
+  private final RootFs rootFs;
+
+  AutoValue_ImageInfo(
+      String id,
+      String parent,
+      String comment,
+      Date created,
+      String container,
+      ContainerConfig containerConfig,
+      String dockerVersion,
+      String author,
+      ContainerConfig config,
+      String architecture,
+      String os,
+      Long size,
+      Long virtualSize,
+      RootFs rootFs) {
+    if (id == null) {
+      throw new NullPointerException("Null id");
+    }
+    this.id = id;
+    if (parent == null) {
+      throw new NullPointerException("Null parent");
+    }
+    this.parent = parent;
+    if (comment == null) {
+      throw new NullPointerException("Null comment");
+    }
+    this.comment = comment;
+    if (created == null) {
+      throw new NullPointerException("Null created");
+    }
+    this.created = created;
+    if (container == null) {
+      throw new NullPointerException("Null container");
+    }
+    this.container = container;
+    if (containerConfig == null) {
+      throw new NullPointerException("Null containerConfig");
+    }
+    this.containerConfig = containerConfig;
+    if (dockerVersion == null) {
+      throw new NullPointerException("Null dockerVersion");
+    }
+    this.dockerVersion = dockerVersion;
+    if (author == null) {
+      throw new NullPointerException("Null author");
+    }
+    this.author = author;
+    if (config == null) {
+      throw new NullPointerException("Null config");
+    }
+    this.config = config;
+    if (architecture == null) {
+      throw new NullPointerException("Null architecture");
+    }
+    this.architecture = architecture;
+    if (os == null) {
+      throw new NullPointerException("Null os");
+    }
+    this.os = os;
+    if (size == null) {
+      throw new NullPointerException("Null size");
+    }
+    this.size = size;
+    this.virtualSize = virtualSize;
+    this.rootFs = rootFs;
+  }
+
+  @JsonProperty(value = "Id")
+  @Override
+  public String id() {
+    return id;
+  }
+
+  @JsonProperty(value = "Parent")
+  @Override
+  public String parent() {
+    return parent;
+  }
+
+  @JsonProperty(value = "Comment")
+  @Override
+  public String comment() {
+    return comment;
+  }
+
+  @JsonProperty(value = "Created")
+  @Override
+  public Date created() {
+    return created;
+  }
+
+  @JsonProperty(value = "Container")
+  @Override
+  public String container() {
+    return container;
+  }
+
+  @JsonProperty(value = "ContainerConfig")
+  @Override
+  public ContainerConfig containerConfig() {
+    return containerConfig;
+  }
+
+  @JsonProperty(value = "DockerVersion")
+  @Override
+  public String dockerVersion() {
+    return dockerVersion;
+  }
+
+  @JsonProperty(value = "Author")
+  @Override
+  public String author() {
+    return author;
+  }
+
+  @JsonProperty(value = "Config")
+  @Override
+  public ContainerConfig config() {
+    return config;
+  }
+
+  @JsonProperty(value = "Architecture")
+  @Override
+  public String architecture() {
+    return architecture;
+  }
+
+  @JsonProperty(value = "Os")
+  @Override
+  public String os() {
+    return os;
+  }
+
+  @JsonProperty(value = "Size")
+  @Override
+  public Long size() {
+    return size;
+  }
+
+  @JsonProperty(value = "VirtualSize")
+  @Override
+  public Long virtualSize() {
+    return virtualSize;
+  }
+
+  @JsonProperty(value = "RootFS")
+  @Override
+  public RootFs rootFs() {
+    return rootFs;
+  }
+
+  @Override
+  public String toString() {
+    return "ImageInfo{"
+        + "id=" + id + ", "
+        + "parent=" + parent + ", "
+        + "comment=" + comment + ", "
+        + "created=" + created + ", "
+        + "container=" + container + ", "
+        + "containerConfig=" + containerConfig + ", "
+        + "dockerVersion=" + dockerVersion + ", "
+        + "author=" + author + ", "
+        + "config=" + config + ", "
+        + "architecture=" + architecture + ", "
+        + "os=" + os + ", "
+        + "size=" + size + ", "
+        + "virtualSize=" + virtualSize + ", "
+        + "rootFs=" + rootFs
+        + "}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof ImageInfo) {
+      ImageInfo that = (ImageInfo) o;
+      return (this.id.equals(that.id()))
+           && (this.parent.equals(that.parent()))
+           && (this.comment.equals(that.comment()))
+           && (this.created.equals(that.created()))
+           && (this.container.equals(that.container()))
+           && (this.containerConfig.equals(that.containerConfig()))
+           && (this.dockerVersion.equals(that.dockerVersion()))
+           && (this.author.equals(that.author()))
+           && (this.config.equals(that.config()))
+           && (this.architecture.equals(that.architecture()))
+           && (this.os.equals(that.os()))
+           && (this.size.equals(that.size()))
+           && ((this.virtualSize == null) ? (that.virtualSize() == null) : this.virtualSize.equals(that.virtualSize()))
+           && ((this.rootFs == null) ? (that.rootFs() == null) : this.rootFs.equals(that.rootFs()));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= this.id.hashCode();
+    h *= 1000003;
+    h ^= this.parent.hashCode();
+    h *= 1000003;
+    h ^= this.comment.hashCode();
+    h *= 1000003;
+    h ^= this.created.hashCode();
+    h *= 1000003;
+    h ^= this.container.hashCode();
+    h *= 1000003;
+    h ^= this.containerConfig.hashCode();
+    h *= 1000003;
+    h ^= this.dockerVersion.hashCode();
+    h *= 1000003;
+    h ^= this.author.hashCode();
+    h *= 1000003;
+    h ^= this.config.hashCode();
+    h *= 1000003;
+    h ^= this.architecture.hashCode();
+    h *= 1000003;
+    h ^= this.os.hashCode();
+    h *= 1000003;
+    h ^= this.size.hashCode();
+    h *= 1000003;
+    h ^= (virtualSize == null) ? 0 : this.virtualSize.hashCode();
+    h *= 1000003;
+    h ^= (rootFs == null) ? 0 : this.rootFs.hashCode();
+    return h;
+  }
+
+}


### PR DESCRIPTION
Add hack to override the way ImageInfo is parsed from Docker Engine

The VirtualSize field was deprecated in API 1.43 and removed in API 1.44 but we dont seem to actually rely on it. This hack overrides the class from inside the Spotify docker-client such that the field is considered optional from the API.

Still needs https://github.com/gocd-contrib/docker-elastic-agents-plugin/issues/258 as a longer term fix.